### PR TITLE
Disable service links for Postgres

### DIFF
--- a/charts/gxf/Chart.yaml
+++ b/charts/gxf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: gxf
 description: Generic GXF Helm chart
-version: '1.2.18'
+version: '1.2.19'
 icon: https://artwork.lfenergy.org/projects/grid-exchange-fabric/abbrev/color/grid-exchange-fabric-abbrev-color.png
 maintainers:
   - name: OSGP

--- a/charts/gxf/Chart.yaml
+++ b/charts/gxf/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
   repository: "https://osgp.github.io/charts/"
   condition: activemq-artemis.enabled
 - name: postgresql
-  version: "8.6.3"
-  repository: "https://charts.helm.sh/stable"
+  version: "11.1.12"
+  repository: "https://charts.bitnami.com/bitnami"
   condition: postgresql.enabled
 engine: gotpl

--- a/charts/gxf/Chart.yaml
+++ b/charts/gxf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: gxf
 description: Generic GXF Helm chart
-version: '1.2.19'
+version: '1.2.22'
 icon: https://artwork.lfenergy.org/projects/grid-exchange-fabric/abbrev/color/grid-exchange-fabric-abbrev-color.png
 maintainers:
   - name: OSGP

--- a/charts/gxf/templates/deployment.yaml
+++ b/charts/gxf/templates/deployment.yaml
@@ -173,3 +173,4 @@ spec:
 {{- end}}
 {{- end }}
       terminationGracePeriodSeconds: 60
+      enableServiceLinks: false

--- a/charts/gxf/values.yaml
+++ b/charts/gxf/values.yaml
@@ -21,6 +21,12 @@ imagePullPolicy: IfNotPresent
 
 postgresql:
   enabled: false
+  primary:
+    extraPodSpec:
+      enableServiceLinks: false
+  readReplicas:
+    extraPodSpec:
+      enableServiceLinks: false
 
 resources:
   limits:


### PR DESCRIPTION
1000+ services in the same namespace will potentially degrade pod start time and eventually prevent pods from starting (See Kubernetes/Kubernetes#92615). This is also the case for [Bitnami Postgresql](https://github.com/bitnami/charts/tree/master/bitnami/postgresql).

Disabling injecting the service links as environment variables (set `enableServiceLinks` to false in the `PodSpec`) speeds up the intialization of the Postgres container from a few minutes to tens of milliseconds.