### PR TITLE
FDP-892: PVC storage class for Openshift

### DIFF
--- a/charts/activemq-artemis/Chart.yaml
+++ b/charts/activemq-artemis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: activemq-artemis
-version: 0.0.12
+version: 0.0.13
 description: a multi-protocol, embeddable, very high performance, clustered, asynchronous messaging system.
 keywords:
 - activemq

--- a/charts/activemq-artemis/templates/pvc.yaml
+++ b/charts/activemq-artemis/templates/pvc.yaml
@@ -20,4 +20,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-{{- end }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/activemq-artemis/templates/pvc.yaml
+++ b/charts/activemq-artemis/templates/pvc.yaml
@@ -8,19 +8,13 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{- if .Values.persistence.storageClass }}
+{{- if .Values.persistence.storageClass }}
   storageClassName: {{ .Values.persistence.storageClass | quote }}
-  {{- end }}
-  {{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Openshift looks at storageClassName in spec, not the annotations. Tested on EKS as well.