### PR TITLE
Remove labels from stateful set

### DIFF
--- a/charts/activemq-artemis/Chart.yaml
+++ b/charts/activemq-artemis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: activemq-artemis
-version: 0.0.15
+version: 0.0.16
 description: a multi-protocol, embeddable, very high performance, clustered, asynchronous messaging system.
 keywords:
 - activemq

--- a/charts/activemq-artemis/templates/statefulsets.yaml
+++ b/charts/activemq-artemis/templates/statefulsets.yaml
@@ -4,9 +4,6 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
 spec:
   serviceName: {{ template "fullname" . }}
   replicas: {{ .Values.replicas }}
@@ -14,16 +11,10 @@ spec:
   selector:
     matchLabels:
       app: {{ template "fullname" . }}
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-      release: "{{ .Release.Name }}"
-      heritage: "{{ .Release.Service }}"
   template:
     metadata:
       labels:
         app: {{ template "fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
-        heritage: "{{ .Release.Service }}"
       annotations:
         prometheus.io/port: '9404'
         prometheus.io/scrape: 'true'


### PR DESCRIPTION
Updating labels is not allowed on stateful sets. Upgrading the chart shouldn't require a force update of the set.

Signed-off-by: Jasper Kamerling <jasper.kamerling@alliander.com>